### PR TITLE
clarify trust_anchor

### DIFF
--- a/openid-federation-entity-collection-1_0.md
+++ b/openid-federation-entity-collection-1_0.md
@@ -158,13 +158,13 @@ If this parameter is present, the number of results in the returned list MUST NO
 If this parameter is not present the server MUST fall back on the upper limit.  
   If the responder does not support this feature, it MUST return an error response with the error code `unsupported_parameter` as defined in [Error Response Format](#error-response-format).
   
+- **trust_anchor**: (REQUIRED) The Trust Anchor that the collection endpoint MUST use when collecting Entities. The value is an Entity Identifier.
+
 - **entity_type**: (OPTIONAL) The value of this parameter is an Entity Type Identifier. The result MUST be filtered to include only those entities that include the specified Entity Type. When multiple `entity_type` parameters are present, for example `entity_type=openid_provider&entity_type=openid_relying_party`, the result MUST be filtered to include all Entities that include any of the specified Entity Types. 
 If the responder does not support this feature, it MUST return an error response with the error code `unsupported_parameter` as defined in [Error Response Format](#error-response-format).
 
 - **trust_mark_type**: (OPTIONAL) The value of this parameter is a Trust Mark Type Identifier. The result MUST be filtered to include only Entities that publish a Trust Mark of this Trust Mark Type in their Entity Configuration and that Trust Mark MUST be verified by the responder. The responder SHOULD verify the Trust Mark using the same Trust Anchor that is used to collect the Entities. When multiple `trust_mark_type` parameters are present, the result MUST be filtered to include only Entities that have a Trust Mark for all the specified Trust Mark Types.  
 If the responder does not support this feature, it MUST return an error response with the error code `unsupported_parameter` as defined in [Error Response Format](#error-response-format).
-
-- **trust_anchor**: (RECOMMENDED) The Trust Anchor that the collection endpoint MUST use when collecting Entities. The value is an Entity Identifier. If omitted, the responder sets this parameter to its own Entity Identifier. If the responder does not have a defined Entity Identifier, it MUST return an error response with the error code `invalid_request` as defined in [Error Response Format](#error-response-format).
 
 - **query**: (OPTIONAL) The value of this parameter is used by the responder to
 filter down the list of returned Entities to only entities that match this
@@ -303,7 +303,6 @@ If the request was malformed or an error occurred during the processing of the r
 
 - **error**: (REQUIRED) Error codes in the IANA "OAuth Extensions Error Registry" [@!IANA.OAuth.Parameters] MAY be used. In particular, these existing error codes are used by this specification:
   - **unsupported_parameter**: The server does not support a requested parameter. The HTTP response status code SHOULD be 400 (Bad Request).
-   - **invalid_request**: The request is incomplete or does not comply with current specifications. The HTTP response status code SHOULD be 400 (Bad Request).  
      <br/>
      In addition the following error codes defined by this specification MAY be used:
   - **page_not_found**: The pagination pointer provided in the `from` parameter is not or no longer known to the responder. The HTTP response status code SHOULD be 404 (Not Found).

--- a/openid-federation-entity-collection-1_0.md
+++ b/openid-federation-entity-collection-1_0.md
@@ -537,6 +537,7 @@ and the Geant Trust & Identity Incubator of Geant5-2.
 -01
 
 * Clarified the description of the `last_updated` response field to specify that it refers to when the responder last traversed or refreshed its federation entity collection.
+* Make the `trust_anchor` parameter REQUIRED.
 
 -00
 

--- a/openid-federation-entity-collection-1_0.md
+++ b/openid-federation-entity-collection-1_0.md
@@ -96,6 +96,8 @@ The Federation Entity Collection Endpoint is an optional endpoint that MAY be pu
 Federation Entities publishing this endpoint SHOULD also publish a
 `federation_resolve_endpoint`.
 
+An entity providing this endpoint does not need to be part of the federation itself, nor does it need to act as a Trust Anchor. In such cases, the `trust_anchor` request parameter is effectively required for the responder to produce a non-empty response.
+
 ## Pagination
 By segmenting the data into pages, the endpoint facilitates the efficient transmission and processing of data and also adds to the client's ability to navigate through the information.
 The selected method of pagination offers a mix of consistency and performance characteristics appropriate for the intended use of the endpoint.
@@ -158,13 +160,14 @@ If this parameter is present, the number of results in the returned list MUST NO
 If this parameter is not present the server MUST fall back on the upper limit, as described in [Response Limits](#response-limits).  
   If the responder does not support this feature, it MUST return an error response with the error code `unsupported_parameter` as defined in [Error Response Format](#error-response-format).
   
-- **trust_anchor**: (REQUIRED) The Trust Anchor that the collection endpoint MUST use when collecting Entities. The value is an Entity Identifier.
-
 - **entity_type**: (OPTIONAL) The value of this parameter is an Entity Type Identifier. The result MUST be filtered to include only those entities that include the specified Entity Type. When multiple `entity_type` parameters are present, for example `entity_type=openid_provider&entity_type=openid_relying_party`, the result MUST be filtered to include all Entities that include any of the specified Entity Types. 
 If the responder does not support this feature, it MUST return an error response with the error code `unsupported_parameter` as defined in [Error Response Format](#error-response-format).
 
 - **trust_mark_type**: (OPTIONAL) The value of this parameter is a Trust Mark Type Identifier. The result MUST be filtered to include only Entities that publish a Trust Mark of this Trust Mark Type in their Entity Configuration and that Trust Mark MUST be verified by the responder. The responder SHOULD verify the Trust Mark using the same Trust Anchor that is used to collect the Entities. When multiple `trust_mark_type` parameters are present, the result MUST be filtered to include only Entities that have a Trust Mark for all the specified Trust Mark Types.  
 If the responder does not support this feature, it MUST return an error response with the error code `unsupported_parameter` as defined in [Error Response Format](#error-response-format).
+
+- **trust_anchor**: (RECOMMENDED) The Trust Anchor that the collection endpoint MUST use when collecting Entities. The value is an Entity Identifier. If omitted, the responder sets this parameter to its own Entity Identifier. If this parameter is omitted and the responder does not have a defined Entity Identifier (e.g., because it is not part of a federation), it MUST return an error response with the error code `invalid_request` as defined in [Error Response Format](#error-response-format). If this parameter is omitted and the responder is not itself a Trust Anchor, the response will be empty by definition.  
+If the requested Trust Anchor is not supported by the responder, it MUST return an error response with the error code `invalid_trust_anchor` as defined in [Error Response Format](#error-response-format).
 
 - **query**: (OPTIONAL) The value of this parameter is used by the responder to
 filter down the list of returned Entities to only entities that match this
@@ -305,6 +308,7 @@ If the request was malformed or an error occurred during the processing of the r
 
 - **error**: (REQUIRED) Error codes in the IANA "OAuth Extensions Error Registry" [@!IANA.OAuth.Parameters] MAY be used. In particular, these existing error codes are used by this specification:
   - **unsupported_parameter**: The server does not support a requested parameter. The HTTP response status code SHOULD be 400 (Bad Request).
+  - **invalid_request**: The request is incomplete or does not comply with current specifications. The HTTP response status code SHOULD be 400 (Bad Request).  
      <br/>
       In addition the following error codes defined by this specification MAY be used:
   - **page_not_found**: The pagination pointer provided in the `from` parameter is not or no longer known to the responder. The HTTP response status code SHOULD be 404 (Not Found).
@@ -627,7 +631,7 @@ and the Geant Trust & Identity Incubator of Geant5-2.
 -01
 
 * Clarified the description of the `last_updated` response field to specify that it refers to when the responder last traversed or refreshed its federation entity collection.
-* Make the `trust_anchor` parameter REQUIRED.
+* Clarified the `trust_anchor` parameter description: explained that the responder need not be part of a federation, and that omitting the parameter when the responder is not a Trust Anchor results in an empty response.
 * Added references to Entity Info and Entity Type UI Info sections in `entity_claims` and `ui_claims` parameter descriptions.
 * Added `unsupported_claim` error code for unsupported claims in `entity_claims` and `ui_claims` parameters.
 * Added examples demonstrating `entity_claims` and `ui_claims` parameter usage.


### PR DESCRIPTION
Resolves #36 

Originally I thought it would be convenient for clients to have the `trust_anchor` request parameter optional, since I would expect that it is likely to use the same entity that provides the entity collection endpoint as the trust anchor.

When thinking about how to clarify #36 I cam to the conclusion that it is probably the best to instead require the `trust_anchor` parameter. This makes usage more clear for implementers. 